### PR TITLE
Keep the navbar expanded on mobile

### DIFF
--- a/templates/layout.jinja
+++ b/templates/layout.jinja
@@ -12,7 +12,7 @@
     {% endblock %}
   </head>
   <body class='{{body_class}}'>
-    <nav class="navbar navbar-default hidden-xs">
+    <nav class="navbar navbar-default navbar-expand">
       <div class="container">
         <div class="navbar-header">
           <a class="navbar-brand" href="/">
@@ -43,13 +43,6 @@
         </ul>
       </div>
     </nav>
-    <div class="visible-xs" href="/">
-      <img src='{{url_for('static', filename='event-logo.png')}}'>
-      <span class='mobile-intro'>
-        Share your projects <small>(please use desktop)</small>
-      </span>
-      <hr/>
-    </div>
     <div class="container" id='main'>
       <busy-indicator></busy-indicator>
       {% block body %}


### PR DESCRIPTION
Bootstrap hides navbar links by default on mobile, relying on you using their js burger menu thing. This ﻿just makes the nav visible all the time.
Remove now-unneeded mobile-specific message/logo.

This should resolve https://github.com/voc/infobeamer-cms/issues/12 and https://github.com/voc/infobeamer-cms/issues/7

![image](https://github.com/user-attachments/assets/72199d59-b599-481e-bc5d-21d5dfd06ae2)
